### PR TITLE
Set `hard_tabs = true` in `Make` language config

### DIFF
--- a/languages/make/config.toml
+++ b/languages/make/config.toml
@@ -10,3 +10,4 @@ path_suffixes = [
 ]
 line_comments = ["# "]
 brackets = [{ start = "(", end = ")", close = true, newline = true }]
+hard_tabs = true


### PR DESCRIPTION
In https://github.com/zed-industries/zed/pull/10296 we added support for extensions to provide certain language settings.

Someone had contributed this fix to Zed to make `Make` files use hard tabs in: https://github.com/zed-industries/zed/pull/9978.

However, now that can be provided by the extension itself.

Once we've published a new version of the Make extension and get it into circulation we'll be able to remove the setting from the Zed defaults.