### PR TITLE
Add outlines

### DIFF
--- a/languages/make/outline.scm
+++ b/languages/make/outline.scm
@@ -1,0 +1,16 @@
+; Rule with no prerequisites
+((comment)* @annotation
+ .
+ (rule
+    (targets) @name
+    !normal) @item)
+
+; Rule with normal prerequisites
+((comment)* @annotation
+ .
+ (rule
+    (targets) @name
+    .
+    ":" @context
+    .
+    normal: (prerequisites) @context) @item)


### PR DESCRIPTION
Add outlines for Makefiles addressing #9 

There is an aesthetic choice made in this PR: the ':' after the target is only included in the outline (as context) if there are "normal" prerequisites following it (which would then also be included as context). Otherwise in the outline it would be a little strange to see `target:` with the next target on the next line as if that next target was related in some way.

Here are some screenshots of the breadcrumbs and outline panel with these suggested changes:

![Screenshot from 2025-03-13 23-59-04](https://github.com/user-attachments/assets/bdac5151-3793-494a-bef7-a613a55c8c65)

![image](https://github.com/user-attachments/assets/353866dd-3a32-41a2-8647-debda98d3db3)


Minor: Any comments immediately preceding a rule are captured as "annotations" which have no visual effect but may improve LLM integrations.
