### PR TITLE
Add runnables for make targets

### DIFF
--- a/languages/make/runnables.scm
+++ b/languages/make/runnables.scm
@@ -1,0 +1,3 @@
+(rule
+    (targets) @run @target
+    (#set! tag make-target))

--- a/languages/make/tasks.json
+++ b/languages/make/tasks.json
@@ -1,0 +1,8 @@
+[
+  {
+    "label": "make target",
+    "command": "make -f $ZED_FILENAME $ZED_CUSTOM_target",
+    "cwd": "$ZED_DIRNAME",
+    "tags": ["make-target"]
+  }
+]


### PR DESCRIPTION
Addresses #8 

This PR makes sure that `make` is called from the same directory as the Makefile that is open, and passes the filename to `make` too in case there is more than one in the directory.

Preview:

![image](https://github.com/user-attachments/assets/d0db9faa-2303-4f90-a467-2b19517ac0dc)

