### PR TITLE
Move 'foreach' from @repeat to @keyword.function.

### DIFF
--- a/languages/make/highlights.scm
+++ b/languages/make/highlights.scm
@@ -1,3 +1,6 @@
+;; This file is a copy of the upstream tree-sitter-make file: https://github.com/tree-sitter-grammars/tree-sitter-make/blob/main/queries/highlights.scm
+;; Except as noted below to accommodate Zed limitations.
+
 [
  "("
  ")"
@@ -59,7 +62,8 @@
  "and"
 ] @conditional
 
-"foreach" @repeat
+;; Zed doesn't support @repeat for highlighting, so move this keyword to @keyword.function
+;"foreach" @repeat
 
 [
  "define"
@@ -107,6 +111,8 @@
  "file"
  "value"
  "shell"
+ ;; Zed doesn't support @repeat for highlighting, so move this keyword to @keyword.function
+ "foreach"
 ] @keyword.function
 
 [


### PR DESCRIPTION
Zed doesn't support `@repeat` for highlighting, so in order to get the `foreach` keyword to be highlighted it needs to be listed as the less correct `@keyword.function`.

/closes #20 