### PR TITLE
Allows Use of Shebang to process Makefiles

### DIFF
--- a/languages/make/config.toml
+++ b/languages/make/config.toml
@@ -8,6 +8,7 @@ path_suffixes = [
   "mk",
   "mak",
 ]
+first_line_pattern = '^#!.*\b(?:make -f)\b'
 line_comments = ["# "]
 brackets = [{ start = "(", end = ")", close = true, newline = true }]
 hard_tabs = true


### PR DESCRIPTION
This helps `rules` Debian files to use make grammar, Debian based distros developers will love using Zed too :)

Closes #15 