### PR TITLE
Do not make targets starting with a `.` then capital (like .PHONY)

### DIFF
--- a/languages/make/runnables.scm
+++ b/languages/make/runnables.scm
@@ -1,3 +1,4 @@
 (rule
     (targets) @run @target
+    (#not-match? @target "^\.[A-Z]")
     (#set! tag make-target))


### PR DESCRIPTION
Addresses https://github.com/caius/zed-make/issues/16 to avoid using "not proper targets" as targets for runnable tasks.

Here's what it looks like with these changes:
![image](https://github.com/user-attachments/assets/773f2f19-3ac7-424c-8d77-fee07e51e089)
